### PR TITLE
Variable name fix

### DIFF
--- a/inst/defaults/lib/utilities.R
+++ b/inst/defaults/lib/utilities.R
@@ -1,7 +1,5 @@
 clean.variable.name <- function(variable.name)
 {
-  variable.name <- gsub('_', '.', variable.name, perl = TRUE)
-  variable.name <- gsub('-', '.', variable.name, perl = TRUE)
-  variable.name <- gsub('\\s+', '.', variable.name, perl = TRUE)
+  variable.name <- make.names(variable.name)
   return(variable.name)
 }


### PR DESCRIPTION
Hi John,

There's a bug in the inst/defaults/lib/utilities.R file in that the clean.variable.name function generates syntactically invalid names if a file's name consists of only numbers, e.g '2006.csv'. This version uses the R function <a href="http://stat.ethz.ch/R-manual/R-devel/library/base/html/make.names.html">make.names()</a> from the base package to generate the correct variable names, which is what R uses internally to clean data.frame names, etc. It will produce names like X2006.

I think it’d be worthwhile to pull it into the project. Thanks for making such a great package!
