### PR TITLE
Use UTF-8 for mysql connections

### DIFF
--- a/R/sql.reader.R
+++ b/R/sql.reader.R
@@ -124,6 +124,7 @@ sql.reader <- function(data.file, filename, variable.name)
                             dbname = database.info[['dbname']],
                             port = as.integer(database.info[['port']]),
                             unix.socket = database.info[['socket']])
+    dbGetQuery(connection, "SET NAMES 'utf8'") # Switch to utf-8 strings
   }
 
   if (database.info[['type']] == 'sqlite')


### PR DESCRIPTION
This will set mysql connections to use utf-8 by default. This seems to be the only way to achieve this with PT, since a new connection is created for each query.
