### PR TITLE
Added JDBC support to sql.reader

### DIFF
--- a/R/sql.reader.R
+++ b/R/sql.reader.R
@@ -187,7 +187,11 @@ sql.reader <- function(data.file, filename, variable.name)
   {
     library('RJDBC')
 
-    rjdbc.driver <- JDBC(database.info[['class']], database.info[['classpath']])
+    ident.quote <- NA
+    if('identquote' %in% names(database.info))
+       ident.quote <- database.info[['identquote']]
+
+    rjdbc.driver <- JDBC(database.info[['class']], database.info[['classpath']], ident.quote)
     connection <- dbConnect(rjdbc.driver,
                             database.info[['url']],
                             user = database.info[['user']],


### PR DESCRIPTION
- classpath can be set in sql file, or via CLASSPATH environment variable
- user/password may be set via variable in sql file, or in jdbc url

Example SQL file:

```
type: jdbc
class: oracle.jdbc.OracleDriver
classpath: /path/to/ojdbc5.jar
user: scott
password: tiger
url: jdbc:oracle:thin:@myhost:1521:orcl
query: select * from emp
```
