### PR TITLE
JDBC connection can use classpath

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 * Fix CRAN checks.
 * project.info is now an active binding to avoid writing to the global environment.
 * Reenabled xlsx.reader.
+* JDBC connection can now use path to jar stored in CLASSPATH
 
 2012-08-11	John Myles White  <jmw@johnmyleswhite.com>
 

--- a/R/sql.reader.R
+++ b/R/sql.reader.R
@@ -190,6 +190,10 @@ sql.reader <- function(data.file, filename, variable.name)
     ident.quote <- NA
     if('identquote' %in% names(database.info))
        ident.quote <- database.info[['identquote']]
+		
+		if(is.null(database.info[['classpath']])) {
+			database.info[['classpath']] = ''
+		}
 
     rjdbc.driver <- JDBC(database.info[['class']], database.info[['classpath']], ident.quote)
     connection <- dbConnect(rjdbc.driver,


### PR DESCRIPTION
Documentation claims that the JDBC reader will work if the jar file is included in the CLASSPATH. This only worked if classpath was included in the .sql file but left empty. Leaving out the classpath setting resulted in NULL being passed to the JDBC connection and throwing an error. It makes sense to me that if the jar file is already included in CLASSPATH then requiring an empty classpath in the .sql file is redundant.
