### PR TITLE
Update wsv.reader.R: use `read.table`, not `read.csv`

### DIFF
--- a/R/wsv.reader.R
+++ b/R/wsv.reader.R
@@ -25,8 +25,7 @@ wsv.reader <- function(data.file, filename, variable.name)
   }
 
   assign(variable.name,
-         read.csv(filename,
-                  header = TRUE,
-                  sep = ' '),
+         read.table(filename,
+                  header = TRUE),
          envir = .TargetEnv)
 }


### PR DESCRIPTION
setting `sep = ' '` for `utils::read.csv()` is not the right approach
because it will see _each_ space as a separator. Whitespace-delimited
data tend to be aligned for viewing with monospaced fonts, so there are
often multiple spaces between columns. `read.table` is probably the
better approach because it assumes an arbitrary length of whitespace
as delimiters.

Using `read.csv()` with such data will throw the following error:

```
Error in read.table(file = file, header = header, sep = sep, quote = quote,  : 
  more columns than column names
```
