### PR TITLE
pass actual variable or character of var name to cache

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -24,7 +24,7 @@
 #' unlink('tmp-project')}
 cache <- function(variable)
 {
-  save(list = variable,
+  save(list = deparse(substitute(variable)),
        envir = .TargetEnv,
        file = file.path('cache',
                         paste(variable, '.RData', sep = '')))


### PR DESCRIPTION
I find it better to pass an actual variable, e.g. cache(myVar) instead of a string containing the variable name. Using deparse and substitute will allow the previous behavior, but can also find the name of a variable argument. This also allows Rstudio, etc., to autocomplete the variable name.
