### PR TITLE
Fix #210 by setting checks for existing project on the absolute path

### DIFF
--- a/R/create.project.R
+++ b/R/create.project.R
@@ -47,11 +47,12 @@ create.project <- function(project.name = 'new-project', template = 'full',
 {
 
   .stopifproject(c("Cannot create a new project inside an existing one",
-                           "Please change to another directory and re-run create.project()"))
+                           "Please change to another directory and re-run create.project()"),
+                 path = normalizePath(dirname(project.name)))
 
   .stopifproject(c("Cannot create a new project inside an existing one",
                    "Please change to another directory and re-run create.project()"),
-                 path = dirname(getwd()))
+                 path = dirname(normalizePath(dirname(project.name))))
 
   merge.strategy <- match.arg(merge.strategy)
   if (.is.dir(project.name)) {

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -238,3 +238,22 @@ test_that('Dont create projects inside other projects', {
         setwd(file.path(test_project, 'lib'))
         expect_error(create.project("new_project"))
 })
+
+test_that('Do create projects on an absolute path from inside project', {
+  test_project <- tempfile('test_project')
+  test_project2 <- tempfile('test_project2')
+  suppressMessages(create.project(test_project, template = 'full'))
+  on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+
+  oldwd <- setwd(test_project)
+  on.exit(setwd(oldwd), add = TRUE)
+
+  # should be able to create a new project outside this one
+  expect_error(create.project(test_project2), NA)
+  on.exit(unlink(test_project2, recursive = TRUE), add = TRUE)
+
+  # But you shouldn't be able to create one inside a sub directory of an
+  # existing project, even on an absolute path outside the current project
+  setwd(file.path(test_project, 'lib'))
+  expect_error(create.project(file.path(test_project2, "munge")))
+})


### PR DESCRIPTION
Fix #210 by setting checks for existing project on the absolute path instead of the current directory

#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [x] Add functionality
 - [x] Add tests
 - [x] Update documentation in `man`
 - [x] Update website documentation

***

#### Proposed changes

I didn't update the documentation since the functionality doesn't change.