### PR TITLE
Created tables_type config variable

### DIFF
--- a/R/load.project.R
+++ b/R/load.project.R
@@ -243,9 +243,11 @@ load.project <- function(...)
       # Get new variables introduced by the reader
       vars.new <- .var.diff.from(vars.old)
 
-      if (config$data_tables) {
+      if (config$tables_type == 'data_table') {
         .convert.to.data.table(vars.new)
-      } else {
+      }
+
+      if (config$tables_type == 'tibble') {
         .convert.to.tibble(vars.new)
       }
 

--- a/R/migrate.project.R
+++ b/R/migrate.project.R
@@ -101,12 +101,32 @@ migrate.project <- function()
     if (grepl("cache_loaded_data", config_warnings)) {
       # switch the setting to FALSE so as to not mess up any existing
       # munge script, but warn the user
+
       loaded.config$cache_loaded_data <- FALSE
       message(paste("",
         "There is a new config item called cache_loaded_data which auto-caches data",
         "after it has been loaded from the data directory.  This has been switched",
         "off for this project in case it breaks your scripts.  However you can switch",
         "it on manually by editing global.dcf",
+        sep = "\n"))
+    }
+
+    if (grepl("tables_type", config_warnings)) {
+      # switch the setting to match data_tables and warn the user
+      # first need to get old data_tables value
+      old.config.values <- translate.dcf(.project.config)
+      if (!is.null(old.config.values$data_tables) &&
+            !is.na(as.logical(old.config.values$data_tables)) &&
+            as.logical(old.config.values$data_tables) 
+          ) {
+        loaded.config$tables_type <- 'data_table'
+      }
+      loaded.config$data_tables <- NULL
+      message(paste("",
+        "data_tables has been renamed tables_type.  It can take the value 'tibble', ",
+        "'data_table', or 'data_frame.  If data_tables is TRUE, tables_type will be",
+        "set to 'data_table', otherwise the default 'tibble' will be used.  if you ",
+        "wish a different default set it manually by editing global.dcf",
         sep = "\n"))
     }
   }

--- a/R/project.config.R
+++ b/R/project.config.R
@@ -15,46 +15,46 @@
 #' @details The options that can be configured in the \code{config/global.dcf} are
 #'  shown below
 #' \tabular{ll}{
-#'  \code{data_loading} \tab This can be set to 'on' or 'off'. If data_loading is on,
+#'  \code{data_loading} \tab This can be set to TRUE or FALSE. If data_loading is on,
 #'  the system will load data from both the cache and data directories with
 #'  cache taking precedence in the case of name conflict. \cr
-#'  \code{data_loading_header} \tab This can be set to 'on' or 'off'. If data_loading_header is on,
+#'  \code{data_loading_header} \tab This can be set to TRUE or FALSE. If data_loading_header is on,
 #'  the system will load text data files, such as CSV, TSV, or XLSX, treating the first row as header. \cr
 #'  \code{data_ignore} \tab A comma separated list of files to be ignored when importing
 #'  from the \code{data/} directory. Regular expressions can be used but should be delimited
 #'   (on both sides) by \code{/}. Note that filenames and filepaths should never begin with
 #'   a \code{/}, entire directories under \code{data/} can be ignored by adding a trailing \code{/}. \cr
-#'  \code{cache_loading} \tab This can be set to 'on' or 'off'. If cache_loading is on,
+#'  \code{cache_loading} \tab This can be set to TRUE or FALSE. If cache_loading is on,
 #'  the system will load data from the cache directory before any attempt to load
 #'  from the data directory. \cr
-#'  \code{recursive_loading} \tab This can be set to 'on' or 'off'. If recursive_loading
+#'  \code{recursive_loading} \tab This can be set to TRUE or FALSE. If recursive_loading
 #'  is on, the system will load data from the data directory and all its sub
 #'  directories recursively.  \cr
-#'  \code{munging} \tab This can be set to 'on' or 'off'. If munging is on, the system
+#'  \code{munging} \tab This can be set to TRUE or FALSE. If munging is on, the system
 #'  will execute the files in the munge directory sequentially using the order
-#'  implied by the sort() function. If munging is off, none of the files in the
+#'  implied by the sort() function. If munging is FALSE, none of the files in the
 #'   munge directory will be executed.  \cr
-#'  \code{logging} \tab This can be set to 'on' or 'off'. If logging is on, a logger
+#'  \code{logging} \tab This can be set to TRUE or FALSE. If logging is on, a logger
 #' object using the log4r package is automatically created when you run
 #' load.project(). This logger will write to the logs directory.  \cr
 #'  \code{logging_level} \tab The value of logging_level is passed to  a logger object
 #' using the log4r package during logging when when you run load.project(). \cr
-#'  \code{load_libraries} \tab  This can be set to 'on' or 'off'. If load_libraries is on,
+#'  \code{load_libraries} \tab  This can be set to TRUE or FALSE. If load_libraries is on,
 #'  the system will load all of the R packages listed in the libraries field
 #'  described below. \cr
 #'  \code{libraries} \tab This is a comma separated list of all the R packages that the user
 #'  wants to automatically load when load.project() is called. These packages must
 #'  already be installed before calling load.project().  \cr
-#'  \code{as_factors} \tab This can be set to 'on' or 'off'. If as_factors is on, the system
+#'  \code{as_factors} \tab This can be set to TRUE or FALSE. If as_factors is on, the system
 #'  will convert every character vector into a factor when creating data frames; most
 #'  importantly, this automatic conversion occurs when reading in data automatically.
-#'  If 'off', character vectors will remain character vectors. \cr
-#'  \code{data_tables} \tab This can be set to 'on' or 'off'. If data_tables is on, the
-#' system will convert every data set loaded from the data directory into a data.table. \cr
-#'  \code{attach_internal_libraries} \tab This can be set to 'on' or 'off'. If
+#'  If FALSE, character vectors will remain character vectors. \cr
+#'  \code{tables_type} \tab This is the format for default tables. Values can be 'tibble' (default),
+#' 'data_table', or 'data_frame \cr
+#'  \code{attach_internal_libraries} \tab This can be set to TRUE or FALSE. If
 #' attach_internal_libraries is on, then every time a new package is loaded into memory
 #' during load.project() a warning will be displayed informing that has happened. \cr
-#'  \code{cache_loaded_data} \tab This can be set to 'on' or 'off'. If cache_loaded_data is
+#'  \code{cache_loaded_data} \tab This can be set to TRUE or FALSE. If cache_loaded_data is
 #'  on, then data loaded from the data directory during load.project() will be
 #'  automatically cached (so it won't need to be reloaded next time load.project()
 #'  is called). \cr

--- a/inst/defaults/config/default.dcf
+++ b/inst/defaults/config/default.dcf
@@ -10,7 +10,7 @@ logging_level: INFO
 load_libraries: FALSE
 libraries: reshape2, plyr, tidyverse, stringr, lubridate
 as_factors: TRUE
-data_tables: FALSE
+tables_type: tibble
 attach_internal_libraries: TRUE
 cache_loaded_data:  FALSE
 sticky_variables: NONE

--- a/inst/defaults/config/types.dcf
+++ b/inst/defaults/config/types.dcf
@@ -10,7 +10,7 @@ logging_level: character
 load_libraries: boolean
 libraries: character
 as_factors: boolean
-data_tables: boolean
+tables_type: character
 attach_internal_libraries: boolean
 cache_loaded_data:  boolean
 sticky_variables: character

--- a/inst/defaults/templates/full/config/global.dcf
+++ b/inst/defaults/templates/full/config/global.dcf
@@ -10,7 +10,7 @@ logging_level: INFO
 load_libraries: FALSE
 libraries: reshape2, plyr, tidyverse, stringr, lubridate
 as_factors: TRUE
-data_tables: FALSE
+tables_type: tibble
 attach_internal_libraries: FALSE
 cache_loaded_data:  TRUE
 sticky_variables: NONE

--- a/inst/defaults/templates/minimal/config/global.dcf
+++ b/inst/defaults/templates/minimal/config/global.dcf
@@ -10,7 +10,7 @@ logging_level: INFO
 load_libraries: FALSE
 libraries: reshape2, plyr, tidyverse, stringr, lubridate
 as_factors: TRUE
-data_tables: FALSE
+tables_type: tibble
 attach_internal_libraries: FALSE
 cache_loaded_data:  TRUE
 sticky_variables: NONE

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -66,3 +66,20 @@ test_that('R code in between back ticks is evaluated in config files', {
         expect_warning(load.project(), "compatible with version 0.1")
 
 })
+
+test_that('Replace data_tables with tables_type', {
+
+  test_project <- tempfile('test_project')
+  suppressMessages(create.project(test_project))
+  on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+
+  oldwd <- setwd(test_project)
+  on.exit(setwd(oldwd), add = TRUE)
+
+  config <- .new.config
+  config$tables_type <- 'tibble'
+  config$data_tables <- NULL
+  write.dcf(config, 'config/global.dcf')
+  expect_warning(load.project(), NA)
+
+})

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -217,3 +217,56 @@ test_that('ignored data files are not loaded', {
   expect_equal(test, test_data)
   expect_false(exists("test.test", envir = .TargetEnv))
 })
+
+test_that('data is loaded as data_frame', {
+        test_project <- tempfile('test_project')
+        suppressMessages(create.project(test_project))
+        on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+
+        oldwd <- setwd(test_project)
+        on.exit(setwd(oldwd), add = TRUE)
+
+        # clear the global environment
+        rm(list=ls(envir = .TargetEnv), envir = .TargetEnv)
+
+        test_data <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
+        
+        # save test data as a csv in the data directory
+        write.csv(test_data, file="data/test.csv", row.names = FALSE)
+
+        config <- .new.config
+        config$tables_type <- "data_frame"
+        write.dcf(config, 'config/global.dcf')
+        
+        suppressMessages(load.project())
+
+        # and check that the loaded data from the cache is what we saved
+        expect_equal(test, test_data)
+})
+
+test_that('data is loaded as data_table', {
+        test_project <- tempfile('test_project')
+        suppressMessages(create.project(test_project))
+        on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+
+        oldwd <- setwd(test_project)
+        on.exit(setwd(oldwd), add = TRUE)
+
+        # clear the global environment
+        rm(list=ls(envir = .TargetEnv), envir = .TargetEnv)
+
+        require('data.table')
+        test_data <- data.table::data.table(data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40)))
+        
+        # save test data as a csv in the data directory
+        write.csv(test_data, file="data/test.csv", row.names = FALSE)
+
+        config <- .new.config
+        config$tables_type <- "data_table"
+        write.dcf(config, 'config/global.dcf')
+        
+        suppressMessages(load.project())
+
+        # and check that the loaded data from the cache is what we saved
+        expect_equal(test, test_data)
+})

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -204,3 +204,65 @@ test_that('migrating a project with a data/*.csv2 file results in a message to u
 
         tidy_up()
 })
+
+test_that('projects without the tables_type config have their migrated config set to tibble', {
+
+        test_project <- tempfile('test_project')
+        suppressMessages(create.project(test_project))
+        on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+
+        oldwd <- setwd(test_project)
+        on.exit(setwd(oldwd), add = TRUE)
+
+        # Read the config data and remove the tables_type config
+        config <- .read.config()
+        expect_error(config$tables_type <- NULL, NA)
+        .save.config(config)
+
+        # should get a warning because of the missing tables_type
+        expect_warning(suppressMessages(load.project()), "missing the following entries: tables_type")
+
+        # Migrate the project
+        expect_message(migrate.project(), "data_tables has been renamed tables_type")
+
+        # Read the config data and check tables_type is 'tibble'
+        config <- .read.config()
+        expect_equal(config$tables_type, 'tibble')
+
+        # Should be a clean load.project
+        expect_warning(suppressMessages(load.project()), NA)
+
+        tidy_up()
+})
+
+test_that('projects without the tables_type config have their migrated config set to data_table', {
+
+        test_project <- tempfile('test_project')
+        suppressMessages(create.project(test_project))
+        on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+
+        oldwd <- setwd(test_project)
+        on.exit(setwd(oldwd), add = TRUE)
+
+        # Read the config data and remove the tables_type config and set data_tables to TRUE
+        config <- .read.config()
+        expect_error(config$tables_type <- NULL, NA)
+        expect_error(config$data_tables <- TRUE, NA)
+        .save.config(config)
+
+        # should get a warning because of the missing tables_type
+        expect_warning(suppressMessages(load.project()), "missing the following entries: tables_type")
+        expect_warning(suppressMessages(load.project()), "contains the following unused entries: data_tables")
+
+        # Migrate the project
+        expect_message(migrate.project(), "data_tables has been renamed tables_type")
+
+        # Read the config data and check tables_type is 'data_table'
+        config <- .read.config()
+        expect_equal(config$tables_type, 'data_table')
+
+        # Should be a clean load.project
+        expect_warning(suppressMessages(load.project()), NA)
+
+        tidy_up()
+})


### PR DESCRIPTION
Takes values 'tibble', 'data_tables', or 'data_frame'
Keeps tibbles as new default
Allows for backwards compatiability with data_frames
Fixes #271

#### Types of change


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

Will need to bump version number once merged.  Requires migration.
#### Pull request checklist

 - [X] Add functionality
 - [X] Add tests
 - [X] Update documentation in `man`
 - [ ] Update website documentation

Waiting until we push to CRAN before changing the website documentation.  This could be a confusing change for CRAN users
***

#### Proposed changes<!-- 
This is fixes issue 271.  Idea is that we can add default table types without breaking backward compatibility.  Rather than forcing default type, users can pick from 3 common types: tibble, data_table, and data_frame.  Eliminates setting flags for things like data_tables.  Also provides flexibility for adding future defaults or supported data frame types.

- 
- 