### PR TITLE
Add cached files to data_ignore

### DIFF
--- a/R/list.data.R
+++ b/R/list.data.R
@@ -102,9 +102,11 @@ list.data <- function(...) {
   cached.vars <- .cached.variables()
   # Exclude variables already found in data/
   cached.vars <- setdiff(cached.vars, varnames)
+  
 
   filenames <- rep('', length(cached.vars))
-  is_ignored <- rep(FALSE, length(cached.vars))
+  is_ignored <- grepl(.prepare.data.ignore.regex(config$data_ignore),
+                      cached.vars)
   is_directory <- rep(FALSE, length(cached.vars))
   cache_only <- rep(TRUE, length(cached.vars))
   readers <- rep('', length(cached.vars))

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -216,6 +216,15 @@ test_that('ignored data files are not loaded', {
                                 recursive_loading = TRUE))
   expect_equal(test, test_data)
   expect_false(exists("test.test", envir = .TargetEnv))
+
+  # reload the project, ignore cached var_to_cache
+  rm(list = ls(envir = .TargetEnv), envir = .TargetEnv)
+  assign("var_to_cache", test_data, envir = .TargetEnv)
+  cache("var_to_cache")
+  rm(var_to_cache, envir = .TargetEnv)
+  suppressMessages(load.project(data_ignore = 'Thumbs.db, var_to_cache'))
+  expect_false(exists("var_to_cache", envir = .TargetEnv))
+ 
 })
 
 test_that('data is loaded as data_frame', {


### PR DESCRIPTION
#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [x] Add functionality
 - [x] Add tests
 - [ ] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes
<!-- 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
 If it fixes a bug or resolves a feature request, be sure to link to that issue. 
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution,
 you did and what alternatives you considered etc.
-->
Fixes #289
If a var name is added to data_ignore that is only in the cache,
the var will not be loaded
