### PR TITLE
Updated for staged install

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -47,18 +47,18 @@
 ## File that specifies default config values to be used in load.project() if config items are missing
 ## from a particular ProjectTemplate directory (because e.g. it was created under a previous version of PT and
 ## migrate.project() hasnt been run yet)
-.default.config.file <- system.file('defaults/config/default.dcf', package = 'ProjectTemplate')
+.default.config.file <- function() system.file('defaults', 'config', 'default.dcf', package = 'ProjectTemplate')
 
 ## File that contains the default initial project configuration after create.project()
-.new.config.file <- system.file('defaults/templates/full/config/global.dcf', package = 'ProjectTemplate')
+.new.config.file <- function() system.file('defaults', 'templates', 'full', 'config', 'global.dcf', package = 'ProjectTemplate')
 
 ## File that contains the datatypes for the options in global.dcf
-.config.types.file <- system.file('defaults/config/types.dcf', package = 'ProjectTemplate')
+.config.types.file <- function() system.file('defaults', 'config', 'types.dcf', package = 'ProjectTemplate')
 
 # read the default and new configurations
-.default.config <- translate.dcf(.default.config.file)
-.new.config <- translate.dcf(.new.config.file)
-.config.types <- translate.dcf(.config.types.file)
+.default.config <- translate.dcf(.default.config.file())
+.new.config <- translate.dcf(.new.config.file())
+.config.types <- translate.dcf(.config.types.file())
 
 # load and validate the config and return a config object
 

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -113,7 +113,7 @@ test_that('migrating a project with a missing config file results in a message t
         suppressMessages(load.project())
 
         # Get the default config
-        default_config <- .read.config(.default.config.file)
+        default_config <- .read.config(.default.config.file())
         default_config$version <- .package.version()
 
         # check the config is all the default
@@ -145,7 +145,7 @@ test_that('migrating a project with a missing config item results in a message t
         suppressMessages(load.project())
 
         # check the missing config item is the default value
-        default_config <- .read.config(.default.config.file)
+        default_config <- .read.config(.default.config.file())
         expect_equal(get.project()$config$data_loading, default_config$data_loading)
 
         tidy_up()


### PR DESCRIPTION
with R 3.6, staged install is the default
hardcoded config paths are changed to functions
see https://developer.r-project.org/Blog/public/2019/02/14/staged-install/index.html

#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [X] Add functionality
 - [ ] Add tests
 - [ ] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes
Staged installation is to be a new feature of R 3.6.0: it is not yet the default in R-devel but it is scheduled to become so on Mar 1.  To turn it on before then, set environment variable R_INSTALL_STAGED=true : this has been done for the fedora-clang results on CRAN.

Tomas Kalibera has written a blog about this which can be seen at
https://developer.r-project.org/Blog/public/2019/02/14/staged-install/index.html .  For most of these packages he has some analysis of the issues at
https://github.com/kalibera/rstagedinst/tree/master/hardcoded
and is happy to help with interpretation (he is Cc:ed here).

Please adjust your package to work with staged installation, if possible before Mar 1.  A stopgap measure is to opt out by adding

StagedInstall: no

in the DESCRIPTION file, and the CRAN team will do that for any remaining packages on which others depend (currently EmiStatR ProjectTemplate Rblpapi gWidgets2 nimble rfishbase) when the default is switched.


- 
- 
