### PR TITLE
changed parent of 'new.env()' to '.TargetEnv' so that 'CODE' supports…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: r
-sudo: false 
 cache: packages
 warnings_are_errors: true
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ addons:
       - r-cran-rodbc
 r_github_packages:
   - johnmyleswhite/log4r
+before_install:
+  - sudo $(which R) CMD javareconf

--- a/R/cache.R
+++ b/R/cache.R
@@ -328,7 +328,7 @@ cache <- function(variable=NULL, CODE=NULL, depends=NULL,  ...)
 #'
 #' @rdname internal.evaluate.code
 .evaluate.code <- function (variable, CODE) {
-        result <- eval(parse(text=CODE), envir = new.env())
+        result <- eval(parse(text=CODE), envir = new.env(parent = .TargetEnv))
         assign(variable, result, envir = .TargetEnv)
 }
 


### PR DESCRIPTION
… `data.table`s

#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [x] Add functionality
 - [ ] Add tests
 - [ ] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes
<!-- 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
 If it fixes a bug or resolves a feature request, be sure to link to that issue. 
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution,
 you did and what alternatives you considered etc.
-->

Using `data.table`s inside the `CODE` argument of the `cache` function can cause errors most likely related to the package namespace and non-standard evaluation:
```
library(ProjectTemplate)
library(data.table)

cache("foo", {
    bla <- data.table(bar = 1:12)
    bla[bar <= 6, ]
})
```
> Loading required namespace: formatR
> Creating cache entry from CODE: foo
> Error in `[.data.frame`(x, i, j) : object 'bar' not found 

Changing the parent of the `new.env()` (where the `CODE` argument is evaluated in) to `.TargetEnv`, which seems to be an internal reference to the global environment, fixes this problem:
```
library(ProjectTemplate)
library(data.table)

cache("foo", {
    bla <- data.table(bar = 1:12)
    bla[bar <= 6, ]
})
```
> Loading required namespace: formatR
> Creating cache entry from CODE: foo
> Loading required namespace: digest