### PR TITLE
ability to create subdirectories in munge and logs. ability to pass names of files to run from munge

### DIFF
--- a/R/load.project.R
+++ b/R/load.project.R
@@ -340,11 +340,25 @@ load.project <- function(...)
 .munge.data <- function(config, my.project.info) {
   message('Munging data')
   if("munge_sub_dir" %in% names(config$.override.config)){
-    dir_name= file.path("munge",config$.override.config[["munge_sub_dir"]])
+    dir_name <- file.path("munge",config$.override.config[["munge_sub_dir"]])
   } else {
-    dir_name='munge'
+    dir_name <-'munge'
   }
-  for (preprocessing.script in sort(dir(dir_name, pattern = '[.][rR]$')))
+
+  munge_files <- function(dir_name){
+    if("munge_files" %in% names(config$.override.config)){
+      munge.files <- paste0(config$.override.config[["munge_files"]], collapse="|")
+    } else{
+      munge.files <- '[.][rR]$'
+    }
+
+    munge.files
+
+    return(munge.files)
+  }
+
+
+  for (preprocessing.script in sort(dir(dir_name, pattern = munge_files())))
   {
     message(' Running preprocessing script: ', preprocessing.script)
     source(file.path(dir_name, preprocessing.script), local = .TargetEnv)

--- a/R/load.project.R
+++ b/R/load.project.R
@@ -339,14 +339,18 @@ load.project <- function(...)
 #' @rdname internal.munge.data
 .munge.data <- function(config, my.project.info) {
   message('Munging data')
-  for (preprocessing.script in sort(dir('munge', pattern = '[.][rR]$')))
+  if("munge_sub_dir" %in% names(config$.override.config)){
+    dir_name= file.path("munge",config$.override.config[["munge_sub_dir"]])
+  } else {
+    dir_name='munge'
+  }
+  for (preprocessing.script in sort(dir(dir_name, pattern = '[.][rR]$')))
   {
     message(' Running preprocessing script: ', preprocessing.script)
-    source(file.path('munge', preprocessing.script), local = .TargetEnv)
+    source(file.path(dir_name, preprocessing.script), local = .TargetEnv)
   }
   return(my.project.info)
 }
-
 
 # Auxiliary functions for loading/unloading projects -------------------------
 

--- a/R/load.project.R
+++ b/R/load.project.R
@@ -128,7 +128,11 @@ load.project <- function(...)
   logger <- log4r::create.logger()
   .provide.directory('logs')
 
-  log4r::logfile(logger) <- file.path('logs', 'project.log')
+  if("logs_sub_dir" %in% names(config$.override.config)){
+    log4r::logfile(logger) <- file.path('logs',config$.override.config$logs_sub_dir, 'project.log')
+  } else {
+    log4r::logfile(logger) <- file.path('logs', 'project.log')
+  }
   log4r::level(logger) <- config$logging_level
   assign('logger', logger, envir = .TargetEnv)
   return(my.project.info)
@@ -364,6 +368,14 @@ load.project <- function(...)
     warning("Creating missing directory ", name)
     dir.create(name)
   }
+  if("logs_sub_dir" %in% names(config$.override.config)){
+    is.dir <- file.info(file.path(name,config$.override.config$logs_sub_dir))$isdir
+    if (is.na(is.dir) || !is.dir) {
+      warning("Creating missing directory ", name)
+      dir.create(file.path(name,config$.override.config$logs_sub_dir))
+    }
+  }
+
 }
 
 

--- a/R/load.project.R
+++ b/R/load.project.R
@@ -351,12 +351,8 @@ load.project <- function(...)
     } else{
       munge.files <- '[.][rR]$'
     }
-
-    munge.files
-
     return(munge.files)
   }
-
 
   for (preprocessing.script in sort(dir(dir_name, pattern = munge_files())))
   {

--- a/docs/configuring.markdown
+++ b/docs/configuring.markdown
@@ -66,3 +66,21 @@ This only works for calls to `add.config` with the parameter `apply.override` se
 to `TRUE`, for the moment this parameter defaults to `FALSE`. The `globals.R` file
 in the standard `full` template therefore includes two calls to `add.config` with
 an explanation which section could be overridden.
+
+
+###Additional parameters
+* `munge_files`: passing munge_files to load_project allows you to run a givien list of munge files in the munge directory
+
+    > load.project(munge_files=c("01-preprocess.R", "03-output.R"))
+
+* `logs_sub_dir`: logs_sub_dir can be set to maintain multiple log files for every run of the project. this will create a  subdirectory under logs directory. the logs will then be written to logs/<subdirectory_name>/project.log
+
+    > load.project(logs_sub_dir= "08-02-2021")
+
+* `munge_sub_dir`: munge_sub_dir can be set to run files from a subdirectory under munge. e.g. munge folder contains directories for multiple experiments, munge/experiment1 , munge/experiment2 , then set munge_sub_dir="experiment1" to run only those files in munge/experiment1
+
+    > load.project(munge_sub_dir = "experiment1")
+
+Running the command below will run files from munge/experiment1 and write logs to logs/experiment1/project.log
+
+    > load.project(munge_sub_dir="experiment1", logs_sub_dir="experiment1")


### PR DESCRIPTION
#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [x ] Add functionality
 - [x ] Add tests
 - [ ] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes

 - ability to create subfolders in logs directory, to maintain log of multiple runs of a project. **logs_sub_dir** is a string parameter, it can be date time stamp or any string. passed to load.project
- ability to create subfolders in munge directory using **munge_sub_dir**  passed to load.project
- ability to pass a vector with names of files to run from munge using **munge_files** passed to load.project
