### PR TITLE
fix pattern not intended for file extensions like .qs.hash

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -483,14 +483,12 @@ cache <- function(variable=NULL, CODE=NULL, depends=NULL,  ...)
 #' @rdname internal.cached.variables
 .cached.variables <- function() {
   cache_format <- .cache.format()
+  cache_ext <- cache_format[["regex_exts"]]["data"]
 
   # get all relevant cache files
-  cache_files <- list.files("cache", pattern = paste(
-    cache_format[["regex_exts"]],
-    collapse = "|"
-  ))
+  cache_files <- list.files("cache", pattern = cache_ext)
   # and return the variable names
-  unique(sub("^(.*)\\..*$", "\\1", cache_files))
+  sub(sprintf("^(.*)%s", cache_ext), "\\1", cache_files)
 }
 
 

--- a/tests/testthat/test-qs.R
+++ b/tests/testthat/test-qs.R
@@ -6,6 +6,26 @@ qsCacheFileFormat <- function() {
   .save.config(config)
 }
 
+test_that("cached variable names are assessed correctly", {
+  test_project <- tempfile("test_project")
+  suppressMessages(create.project(test_project))
+  on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+  oldwd <- setwd(test_project)
+  on.exit(setwd(oldwd), add = TRUE)
+
+  qsCacheFileFormat()
+
+  var_to_cache <- "cache.qs"
+  cache(var_to_cache, iris[1:3, ])
+
+  expect_identical(
+    .cached.variables(),
+    var_to_cache
+  )
+
+  tidy_up()
+})
+
 #### from test-cache.R ####
 test_that('re-caching is skipped when a cached variable hasnt changed', {
   test_project <- tempfile('test_project')


### PR DESCRIPTION
#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [ ] Add functionality
 - [x] Add tests
 - [ ] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes
<!-- 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
 If it fixes a bug or resolves a feature request, be sure to link to that issue. 
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution,
 you did and what alternatives you considered etc.
-->

When adding `qs` as a cache file format, I didn't notice that the pattern used in `sub()` within `.cached.variables()` is not suitable for file extensions like ".qs.hash". The proposed changes are supposed to fix this and to generally optimise said function. Furthermore, they also add a test checking if variable names are now assessed correctly from the cached file names.