### PR TITLE
Added RStudio configuration to create new project

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,6 +75,7 @@ Collate:
     'translate.dcf.R'
     'config.R'
     'create.project.R'
+    'create.project.rstudio.R'
     'create.template.R'
     'csv.reader.R'
     'csv2.reader.R'

--- a/R/create.project.rstudio.R
+++ b/R/create.project.rstudio.R
@@ -1,0 +1,21 @@
+create_project_rstudio <- function(path, template, dump, merge)
+{
+
+  .stopifproject(c("Cannot create a new project inside an existing one",
+                   "Please change to another directory and re-run create.project()"),
+                 path = normalizePath(dirname(path)))
+
+  .stopifproject(c("Cannot create a new project inside an existing one",
+                   "Please change to another directory and re-run create.project()"),
+                 path = dirname(normalizePath(dirname(path))))
+
+  dir.create(path, recursive = TRUE, showWarnings = FALSE)
+
+
+
+  ProjectTemplate::create.project(
+    project.name = path, template = template,
+    dump = dump, merge.strategy = ifelse(merge, "allow.non.conflict", "require.empty"),
+    rstudio.project = TRUE
+  )
+}

--- a/inst/rstudio/templates/project/projecttemplate.dcf
+++ b/inst/rstudio/templates/project/projecttemplate.dcf
@@ -1,0 +1,21 @@
+Binding: create_project_rstudio
+Title: ProjectTemplate project
+OpenFiles: src/eda.R
+
+Parameter: template
+Widget: TextInput
+Label: Template name
+Default: full
+Position: left
+
+Parameter: dump
+Widget: CheckboxInput
+Label: Dump ProjectTemplate files
+Default: Off
+Position: left
+
+Parameter: merge
+Widget: CheckboxInput
+Label: Allow non-conflicting files in directory
+Default: Off
+Position: left


### PR DESCRIPTION
Allows to create a new project from the RStudio "New Project" wizard.

Closes #311

#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [x] Add functionality
 - [ ] Add tests
 - [ ] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes

Added a `inst/rstudio/templates/project/projecttemplate.dcf` file per the instructions on https://rstudio.github.io/rstudio-extensions/rstudio_project_templates.html. A new internal function `create_project_rstudio` was created to parse the options from the wizard. For simplicity of the graphical user interface the `merge.strategy` argument of `ProjectTemplate::create.project` was converted to a boolean checkbox, and the `rstudio.project` argument was fixed to `TRUE`.

As this is only a light wrapper around `create.project` and only accessed through the graphical user interface of rstudio I did not add documentation or tests. If necessary I can add some later.