### PR TITLE
add tidyCODE parameter to cache()

### DIFF
--- a/man/cache.Rd
+++ b/man/cache.Rd
@@ -4,7 +4,7 @@
 \alias{cache}
 \title{Cache a data set for faster loading.}
 \usage{
-cache(variable = NULL, CODE = NULL, depends = NULL, ...)
+cache(variable = NULL, CODE = NULL, depends = NULL, tidyCODE = TRUE, ...)
 }
 \arguments{
 \item{variable}{A character string containing the name of the variable to
@@ -16,6 +16,13 @@ cached.  Requires suggested package formatR}
 
 \item{depends}{A character vector of other global environment objects that the CODE
 depends upon. Caching will be forced if those objects have changed since last caching}
+
+\item{tidyCODE}{A logical scalar specifying if the CODE shall be tidied with
+the help of \code{\link[formatR]{tidy_source}}. As, for example, whitespace
+changes do not change the meaning of the code and therefore should not
+invalidate the cache, this usually is a desired feature. However, in case
+the CODE contains, for example, complex SQL statements this might fail and
+skipping this step is an even more desirable feature.}
 
 \item{...}{Additional arguments passed on to \code{\link{save}} or optionally
 to \code{\link[qs]{qsave}}. See \code{\link{project.config}} for further


### PR DESCRIPTION
#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [x] Add functionality
 - [ ] Add tests
 - [x] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes
<!-- 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
 If it fixes a bug or resolves a feature request, be sure to link to that issue. 
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution,
 you did and what alternatives you considered etc.
-->

Hi Kenton!

I added the parameter `tidyCODE` to the `cache()` function, which is `TRUE` by default, but can be set to `FALSE` in case `formatR::tidy_source()` fails. I experienced problems with `glue::glue()` presumably in combination with SQL queries containing `\"` lately. Escaped double quotes are often necessary to properly quote identifiers in SQL. When `formatR::tidy_source()` fails to handle such a "complex" query, you can end up with `NA` instead of the tidied query, e.g. `result <- sf::st_read(con, query = glue(NA))`.

Since `formatR::tidy_source()` is there to tidy R code and not SQL, I think it is best to just be able to skip tidying completely if necessary.

P.S. More pull requests are in my pipeline, but don't expect anything exciting. ;⁠)