### PR TITLE
don't print "no_cache_dir"

### DIFF
--- a/R/migrate.project.R
+++ b/R/migrate.project.R
@@ -53,7 +53,6 @@ migrate.project <- function()
   csv2_files_present <- any(file.exists(Sys.glob("data/*.csv2")))
   no_cache_dir <- !dir.exists("cache")
   other_conflicts <- any(doc_not_renamed, csv2_files_present, no_cache_dir)
-  print(no_cache_dir)
 
   # Exit if everything up to date
   if (!any(version_conflict, config_conflicts, other_conflicts)) {
@@ -119,7 +118,7 @@ migrate.project <- function()
       old.config.values <- translate.dcf(.project.config)
       if (!is.null(old.config.values$data_tables) &&
             !is.na(as.logical(old.config.values$data_tables)) &&
-            as.logical(old.config.values$data_tables) 
+            as.logical(old.config.values$data_tables)
           ) {
         loaded.config$tables_type <- 'data_table'
       } else {
@@ -170,7 +169,7 @@ migrate.project <- function()
     message(paste("",
       "Caching has become an integral part of ProjectTemplate.  Even if no files are",
       "explicitly cached by the user, ProjectTemplate may still create some caches",
-      "for perfroamcen improvement.  The 'cache' directoy is now requireed.  An empty",
+      "for performance improvement.  The 'cache' directoy is now required.  An empty",
       "cache directory will be created.",
       sep = "\n"
     ))


### PR DESCRIPTION
#### Types of change

<!--
Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (documentation etc)

#### Pull request checklist

 - [ ] Add functionality
 - [ ] Add tests
 - [ ] Update documentation in `man`
 - [ ] Update website documentation

***

#### Proposed changes
<!-- 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
 If it fixes a bug or resolves a feature request, be sure to link to that issue. 
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution,
 you did and what alternatives you considered etc.
-->

For some reason the `migrate.project()` function contains a print statement printing the `no_cache_dir` variable. In case the cache directory already exists, it prints `FALSE` after migrating the project, which is confusing, because it suggests that the migration failed even though it succeeded:
<img width="341" height="115" alt="{688082FF-4024-4E2F-BF3E-E932D0305428}" src="https://github.com/user-attachments/assets/064d7709-a966-4f37-bf80-f7c358ca0014" />

I removed this print statement.